### PR TITLE
Shorten 3d printing notice

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -678,9 +678,7 @@ For example, when the style is obtained from the Van Gogh's painting, the eyes a
 
 
 <p>
-Our approach combines well with modern digital fabrication techniques<d-cite key="gershenfeld2012make,kodama1981automatic,jones2011reprap"></d-cite>.
-The geometry of the object is not part of its parameterization and, therefore, it is not modified during the optimization process.
-Hence, a faithful replica of the object can be 3D printed and, by adopting color printing technologies<d-footnote>Full color sandstone was used to print and color our model.</d-footnote>, it can be textured accordingly to our generated style texture.
+Textured models produced with the presented method can be easily used with popular 3D modeling software or game engines. We even 3d printed one of our designs as a physical world artifact <d-footnote>We used the <a href="https://www.shapeways.com/materials.sandstone">Full-color Sandstone</a> material.</d-footnote>.
 </p>
 
 <!-- =================================================== -->


### PR DESCRIPTION
* removed 3d printing citations, as none of them actually talks about colorful printing
* added the link to shapeways material used for the printing
* mention the possibility to use produced models with 3d modeling software or game engines