### PR TITLE
update bibliography to fix broken Stanford bunny link

### DIFF
--- a/public/bibliography.bib
+++ b/public/bibliography.bib
@@ -234,7 +234,7 @@
   author={Turk, Greg and Levoy, Marc},
   year={2005},
   publisher={Stanford University Computer Graphics Laboratory},
-  url= {http://graphics. stanford. edu/data/3Dscanrep}
+  url= {http://graphics.stanford.edu/data/3Dscanrep}
 }
 
 @book{Shreiner2013OpenGL,


### PR DESCRIPTION
It pointed to (with spaces): "graphics. stanford. edu/data/3Dscanrep"

Link should be: "graphics.stanford.edu/data/3Dscanrep"